### PR TITLE
Add navbar and lot/legal registration forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,9 @@ import { ethers } from "ethers";
 import { connectWallet } from "./utils/wallet";
 import abi from "./abi/MedicineRegistry.json";
 import type { MedicineRegistryContract } from "./types/MedicineRegistry";
+import Navbar from "./components/Navbar";
+import LotForm, { LotData } from "./components/LotForm";
+import LegalForm, { LegalData } from "./components/LegalForm";
 
 const CONTRACT_ADDRESS = "0x4E0fa35846Cf43E9e204C3744607aB66E33827e0"; // Dirección del contrato desplegado
 
@@ -10,8 +13,23 @@ function App() {
   const [account, setAccount] = useState<string>("");
   const [contract, setContract] = useState<MedicineRegistryContract | null>(null);
 
+  const [lotData, setLotData] = useState<LotData>({
+    medicineName: "",
+    manufacturer: "",
+    mfgDate: "",
+    expDate: "",
+    seriesCode: "",
+  });
+
+  const [legalData, setLegalData] = useState<LegalData>({
+    name: "",
+    id: "",
+    phone: "",
+    email: "",
+  });
+
   // conectar MetaMask
-  async function handleConnect() {  
+  async function handleConnect() {
     const conn = await connectWallet();
     if (conn) {
       const { signer } = conn;
@@ -19,25 +37,41 @@ function App() {
       setAccount(address);
 
       // instanciamos el contrato
-      const _contract = new ethers.Contract(CONTRACT_ADDRESS, abi.abi, signer) as unknown as MedicineRegistryContract;
-        setContract(_contract);
-
+      const _contract = new ethers.Contract(
+        CONTRACT_ADDRESS,
+        abi.abi,
+        signer
+      ) as unknown as MedicineRegistryContract;
+      setContract(_contract);
     }
   }
 
-  // registrar lote de prueba
+  const handleLotChange = (field: keyof LotData, value: string) => {
+    setLotData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleLegalChange = (field: keyof LegalData, value: string) => {
+    setLegalData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const generateSeriesCode = () => {
+    const code = `CODE-${Math.floor(Math.random() * 100000)}`;
+    setLotData((prev) => ({ ...prev, seriesCode: code }));
+  };
+
+  // registrar lote usando datos del formulario
   async function registrarLote() {
     if (!contract) return alert("Conecta tu wallet primero");
 
-    const mfg = Math.floor(new Date("2025-01-01").getTime() / 1000);
-    const exp = Math.floor(new Date("2026-01-01").getTime() / 1000);
+    const mfg = Math.floor(new Date(lotData.mfgDate).getTime() / 1000);
+    const exp = Math.floor(new Date(lotData.expDate).getTime() / 1000);
 
     const tx = await contract.registrarLote(
-      "Paracetamol 500mg",
-      "ACME Labs",
+      lotData.medicineName,
+      lotData.manufacturer,
       mfg,
       exp,
-      "LOTE-FRONT-001"
+      lotData.seriesCode
     );
 
     await tx.wait();
@@ -45,16 +79,24 @@ function App() {
   }
 
   return (
-    <div style={{ padding: "20px" }}>
-      <h1>Medicine Registry DApp</h1>
-      {!account ? (
-        <button onClick={handleConnect}>Conectar MetaMask</button>
-      ) : (
-        <>
-          <p>Conectado como: {account}</p>
-          <button onClick={registrarLote}>Registrar lote de prueba</button>
-        </>
-      )}
+    <div className="min-h-screen bg-gray-100">
+      <Navbar onConnect={handleConnect} account={account} />
+      <div className="max-w-4xl mx-auto mt-8">
+        <div className="grid grid-cols-2 gap-6 p-6 border border-dashed border-blue-400 rounded-md bg-gray-50">
+          <LotForm
+            data={lotData}
+            onChange={handleLotChange}
+            onGenerateCode={generateSeriesCode}
+          />
+          <LegalForm data={legalData} onChange={handleLegalChange} />
+        </div>
+        <button
+          onClick={registrarLote}
+          className="mx-auto mt-6 px-6 py-2 border rounded-md bg-white hover:bg-gray-100 block"
+        >
+          Registrar Lote
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/LegalForm.tsx
+++ b/src/components/LegalForm.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+export interface LegalData {
+  name: string;
+  id: string;
+  phone: string;
+  email: string;
+}
+
+interface LegalFormProps {
+  data: LegalData;
+  onChange: (field: keyof LegalData, value: string) => void;
+}
+
+export default function LegalForm({ data, onChange }: LegalFormProps) {
+  return (
+    <div>
+      <h2 className="font-bold mb-4">Representante Legal</h2>
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Nombre completo"
+        value={data.name}
+        onChange={(e) => onChange("name", e.target.value)}
+      />
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Documento de identidad"
+        value={data.id}
+        onChange={(e) => onChange("id", e.target.value)}
+      />
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Teléfono"
+        value={data.phone}
+        onChange={(e) => onChange("phone", e.target.value)}
+      />
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Correo electrónico"
+        value={data.email}
+        onChange={(e) => onChange("email", e.target.value)}
+      />
+    </div>
+  );
+}
+

--- a/src/components/LotForm.tsx
+++ b/src/components/LotForm.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+export interface LotData {
+  medicineName: string;
+  manufacturer: string;
+  mfgDate: string;
+  expDate: string;
+  seriesCode: string;
+}
+
+interface LotFormProps {
+  data: LotData;
+  onChange: (field: keyof LotData, value: string) => void;
+  onGenerateCode: () => void;
+}
+
+export default function LotForm({ data, onChange, onGenerateCode }: LotFormProps) {
+  return (
+    <div>
+      <h2 className="font-bold mb-4">Registro de Lote</h2>
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Nombre del medicamento"
+        value={data.medicineName}
+        onChange={(e) => onChange("medicineName", e.target.value)}
+      />
+      <input
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        placeholder="Fabricante"
+        value={data.manufacturer}
+        onChange={(e) => onChange("manufacturer", e.target.value)}
+      />
+      <input
+        type="date"
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        value={data.mfgDate}
+        onChange={(e) => onChange("mfgDate", e.target.value)}
+      />
+      <input
+        type="date"
+        className="w-full border rounded-md px-3 py-2 mb-3"
+        value={data.expDate}
+        onChange={(e) => onChange("expDate", e.target.value)}
+      />
+      <div className="flex items-center">
+        <input
+          className="w-full border rounded-md px-3 py-2 mb-3"
+          placeholder="Código único de serie"
+          value={data.seriesCode}
+          onChange={(e) => onChange("seriesCode", e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={onGenerateCode}
+          className="bg-blue-600 text-white px-3 py-1 rounded-md ml-2 mb-3"
+        >
+          Generar
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface NavbarProps {
+  onConnect: () => void;
+  account?: string;
+}
+
+export default function Navbar({ onConnect, account }: NavbarProps) {
+  return (
+    <div className="flex justify-between items-center px-6 py-4 shadow-sm bg-white">
+      <div className="text-[#6C63FF] font-semibold">BlockFarm</div>
+      <nav className="flex gap-4">
+        <a href="#" className="text-purple-600 font-semibold border-b-2 border-purple-600">
+          Registrar Lote
+        </a>
+        <a href="#" className="text-gray-600">
+          Otros
+        </a>
+      </nav>
+      {account ? (
+        <span className="rounded-full border px-4 py-1">{account}</span>
+      ) : (
+        <div className="flex gap-2">
+          <button onClick={onConnect} className="rounded-full border px-4 py-1">
+            Iniciar sesión
+          </button>
+          <button className="rounded-full border px-4 py-1">Crear cuenta</button>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add navbar with BlockFarm logo, navigation and session buttons
- create lot and legal representative forms with styled inputs
- integrate forms into App and preserve MetaMask connection

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0c2fac5c4832794e2c3239988e936