### PR TITLE
Implement transfer workflow with modal summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,7 +206,7 @@ function App() {
         </PageWrapper>}
       {activeTab === 'transfer' &&
       <PageWrapper key="transfer">
-       <TransferForm />
+       <TransferForm contract={contract} account={account} />
        </PageWrapper>
        }
       {activeTab === 'register' && lastLotInfo && !showPopup && (

--- a/src/components/TransferForm.tsx
+++ b/src/components/TransferForm.tsx
@@ -1,65 +1,256 @@
+import { FormEvent, useState } from "react";
+import { ethers } from "ethers";
 import PageWrapper from "./Layout/PageWraper";
+import type { MedicineRegistryContract } from "../types/MedicineRegistry";
+import TransferSummaryModal, {
+  TransferSummaryData,
+} from "./TransferSummaryModal";
 
-export default function TransferForm() {
+interface TransferFormProps {
+  contract: MedicineRegistryContract | null;
+  account: string;
+}
+
+export default function TransferForm({
+  contract,
+  account,
+}: TransferFormProps) {
+  const [numeroLote, setNumeroLote] = useState("");
+  const [nombreMedicamento, setNombreMedicamento] = useState("");
+  const [codigoLote, setCodigoLote] = useState("");
+  const [destinatario, setDestinatario] = useState("");
+  const [representante, setRepresentante] = useState("");
+  const [fecha, setFecha] = useState("");
+  const [cantidad, setCantidad] = useState("");
+  const [isTransferring, setIsTransferring] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [summaryData, setSummaryData] = useState<TransferSummaryData | null>(
+    null
+  );
+  const [lastSummary, setLastSummary] = useState<TransferSummaryData | null>(
+    null
+  );
+
+  const resetForm = () => {
+    setNumeroLote("");
+    setNombreMedicamento("");
+    setCodigoLote("");
+    setDestinatario("");
+    setRepresentante("");
+    setFecha("");
+    setCantidad("");
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccessMessage(null);
+
+    if (!contract) {
+      const message = "Conecta tu wallet antes de transferir un lote.";
+      setError(message);
+      alert(message);
+      return;
+    }
+
+    const trimmedCodigo = codigoLote.trim();
+    const trimmedDestinatario = destinatario.trim();
+
+    if (!trimmedCodigo) {
+      const message = "Ingresa el código del lote a transferir.";
+      setError(message);
+      alert(message);
+      return;
+    }
+
+    if (!trimmedDestinatario) {
+      const message = "Ingresa la dirección del destinatario.";
+      setError(message);
+      alert(message);
+      return;
+    }
+
+    if (!ethers.isAddress(trimmedDestinatario)) {
+      const message = "La dirección del destinatario no es válida.";
+      setError(message);
+      alert(message);
+      return;
+    }
+
+    try {
+      setIsTransferring(true);
+      const loteId = ethers.keccak256(ethers.toUtf8Bytes(trimmedCodigo));
+      const tx = await contract.transferirLote(loteId, trimmedDestinatario);
+      await tx.wait();
+
+      const summary: TransferSummaryData = {
+        codigoLote: trimmedCodigo,
+        destinatario: trimmedDestinatario,
+        fecha,
+        cantidad,
+        representante,
+        emisor: account,
+        txHash: tx.hash,
+        numeroLote: numeroLote.trim(),
+        nombreMedicamento: nombreMedicamento.trim(),
+      };
+
+      setSummaryData(summary);
+      setLastSummary(summary);
+      setSuccessMessage(
+        "Transferencia completada. Puedes revisar el resumen."
+      );
+    } catch (err) {
+      console.error(err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : "La transferencia fue cancelada o falló.";
+      setError(message);
+      alert(message);
+    } finally {
+      setIsTransferring(false);
+    }
+  };
+
+  const handleCloseSummary = () => {
+    setSummaryData(null);
+    resetForm();
+  };
+
+  const handleReopenSummary = () => {
+    if (lastSummary) {
+      setSummaryData(lastSummary);
+    }
+  };
+
   return (
     <PageWrapper>
-    <div className="flex flex-col items-center gap-8 my-4 ">
-      <div className="flex md:flex-row gap-80">
-        <div className="p-6 rounded-4xl flex flex-col gap-6 items-center shadow-2xl max-w-3xl border border-gray-300 w-[361px]">
-          <h2 className="text-lg font-bold">Complete los datos del lote</h2>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Datos del emisor</label>
-            <input 
-            className="text-black border rounded-lg px-2 bg-gray-200" 
-            placeholder="Laboratorios Peru S.A.C"
-            disabled
-            />
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col items-center gap-8 my-4"
+      >
+        <div className="flex md:flex-row gap-80">
+          <div className="p-6 rounded-4xl flex flex-col gap-6 items-center shadow-2xl max-w-3xl border border-gray-300 w-[361px]">
+            <h2 className="text-lg font-bold">Complete los datos del lote</h2>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Datos del emisor</label>
+              <input
+                className="text-black border rounded-lg px-2 bg-gray-200"
+                placeholder="Conecta tu wallet"
+                value={account || ""}
+                disabled
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Representante Legal/Técnico</label>
+              <input
+                className="text-black border rounded-lg px-2 bg-gray-200"
+                placeholder="QF Maria Lopez (CIPQF 67890)"
+                disabled
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Número de Lote</label>
+              <input
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={numeroLote}
+                onChange={(event) => setNumeroLote(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Nombre del medicamento</label>
+              <input
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={nombreMedicamento}
+                onChange={(event) => setNombreMedicamento(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Código de lote</label>
+              <input
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={codigoLote}
+                onChange={(event) => setCodigoLote(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
           </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Representante Legal/Técnico</label>
-            <input 
-            className="text-black border rounded-lg px-2  bg-gray-200" 
-            placeholder="QF Maria Lopez(CIPQF 67890)"
-            disabled
-            />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Número de Lote</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Nombre del medicamento</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Código de lote</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
+          <div className="p-6 rounded-4xl flex flex-col gap-6 items-center shadow-2xl max-w-3xl border border-gray-300 w-[361px]">
+            <h2 className="text-lg font-bold">Complete los datos de recepción</h2>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Destinatario</label>
+              <input
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={destinatario}
+                onChange={(event) => setDestinatario(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Representante</label>
+              <input
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={representante}
+                onChange={(event) => setRepresentante(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Fecha</label>
+              <input
+                type="date"
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={fecha}
+                onChange={(event) => setFecha(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
+            <div className="flex flex-col gap-4 w-full">
+              <label className="lot-label">Cantidad</label>
+              <input
+                type="number"
+                min="0"
+                className="text-gray-400 border rounded-lg px-2 hover:border-blue-500"
+                value={cantidad}
+                onChange={(event) => setCantidad(event.target.value)}
+                disabled={isTransferring}
+              />
+            </div>
           </div>
         </div>
-        <div className="p-6 rounded-4xl flex flex-col gap-6 items-center shadow-2xl max-w-3xl border border-gray-300 w-[361px]">
-          <h2 className="text-lg font-bold">Complete los datos de recepción</h2>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Destinatario</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Representante</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Fecha</label>
-            <input type="date" className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
-          <div className="flex flex-col gap-4 w-full">
-            <label className="lot-label">Cantidad</label>
-            <input className="text-gray-400 border rounded-lg px-2 hover:border-blue-500" />
-          </div>
+        <div className="flex flex-col items-center gap-2">
+          <button
+            type="submit"
+            className={`border border-blue-300 bg-blue-500 text-white px-6 py-3 rounded-full shadow-md transition-colors w-[200px] ${
+              isTransferring ? "opacity-50 cursor-not-allowed" : "hover:bg-blue-600"
+            }`}
+            disabled={isTransferring}
+          >
+            {isTransferring ? "Transfiriendo..." : "Realizar transferencia"}
+          </button>
+          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+          {successMessage && (
+            <p className="text-green-600 text-sm text-center">
+              {successMessage}
+            </p>
+          )}
         </div>
-      </div>
-      <button className="border border-blue-300 bg-blue-500 text-white px-6 py-3 rounded-full shadow-md hover:bg-blue-600 transition-colors w-[200px]">
-        Realizar transferencia
-      </button>
-    </div>
+      </form>
+      {summaryData && (
+        <TransferSummaryModal data={summaryData} onClose={handleCloseSummary} />
+      )}
+      {!summaryData && lastSummary && (
+        <div
+          className="fixed bottom-4 right-4 bg-blue-500 text-white px-4 py-2 rounded-full shadow cursor-pointer hover:bg-blue-600"
+          onClick={handleReopenSummary}
+        >
+          Última transferencia
+        </div>
+      )}
     </PageWrapper>
   );
 }

--- a/src/components/TransferSummaryModal.tsx
+++ b/src/components/TransferSummaryModal.tsx
@@ -1,0 +1,85 @@
+export interface TransferSummaryData {
+  codigoLote: string;
+  destinatario: string;
+  fecha: string;
+  cantidad: string;
+  representante: string;
+  emisor: string;
+  txHash: string;
+  numeroLote?: string;
+  nombreMedicamento?: string;
+}
+
+interface TransferSummaryModalProps {
+  data: TransferSummaryData;
+  onClose: () => void;
+}
+
+export default function TransferSummaryModal({
+  data,
+  onClose,
+}: TransferSummaryModalProps) {
+  if (!data) return null;
+
+  const formattedDate = data.fecha
+    ? new Date(data.fecha).toLocaleDateString()
+    : "No registrada";
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50">
+      <div className="flex flex-col gap-4 bg-white rounded-xl shadow-lg p-6 w-[400px] border-blue-300 border">
+        <h2 className="text-xl font-bold mb-4">
+          ✅ Transferencia completada
+        </h2>
+        {data.numeroLote && (
+          <p>
+            <strong>Número de lote:</strong> {data.numeroLote}
+          </p>
+        )}
+        <p>
+          <strong>Código de lote:</strong> {data.codigoLote}
+        </p>
+        {data.nombreMedicamento && (
+          <p>
+            <strong>Medicamento:</strong> {data.nombreMedicamento}
+          </p>
+        )}
+        <p>
+          <strong>Destinatario:</strong> {data.destinatario}
+        </p>
+        <p>
+          <strong>Representante:</strong> {data.representante || "No indicado"}
+        </p>
+        <p>
+          <strong>Fecha:</strong> {formattedDate}
+        </p>
+        <p>
+          <strong>Cantidad:</strong> {data.cantidad || "No indicada"}
+        </p>
+        <p>
+          <strong>Cuenta emisora:</strong> {data.emisor || "No conectada"}
+        </p>
+        <div className="flex justify-center">
+          <a
+            href={`https://sepolia.etherscan.io/tx/${data.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline block mt-2"
+          >
+            Ver en blockchain
+          </a>
+        </div>
+        <div className="flex justify-end mt-4">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
+            type="button"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/types/MedicineRegistry.d.ts
+++ b/src/types/MedicineRegistry.d.ts
@@ -8,6 +8,10 @@ export interface MedicineRegistryContract {
     expDate: number,
     serial: string
   ) => Promise<ContractTransactionResponse>;
+  transferirLote: (
+    loteId: string,
+    nuevoPropietario: string
+  ) => Promise<ContractTransactionResponse>;
   obtenerLote: (
     loteId: string
   ) =>


### PR DESCRIPTION
## Summary
- extend the MedicineRegistry contract typings to include transfer support
- pass the active contract and account into the transfer form and refactor it into a controlled workflow with validation and transaction handling
- add a transfer summary modal to present transaction results with a link to Etherscan

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde2854ef483279545de3abb207910